### PR TITLE
Add missing comma in available repls list to fix install issues

### DIFF
--- a/rplugin/python3/iron/repls/__init__.py
+++ b/rplugin/python3/iron/repls/__init__.py
@@ -17,7 +17,7 @@ available_repls = [
     erlang.repl,
     lua.repl,
     ocaml.utop,
-    ocaml.ocamltop
+    ocaml.ocamltop,
     python.ptipython,
     python.ipython,
     python.ptpython,


### PR DESCRIPTION
After some further looking I found a missing comma in the list.

This should close #6.