### PR TITLE
Improve Logging + REPL management

### DIFF
--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -35,7 +35,7 @@ class Iron(BaseIron):
 
         self.set_mappings(repl, ft)
         self.call_hooks(ft)
-        self.set_repl_id(repl_id)
+        self.set_repl_id(ft, repl_id)
 
         self.set_variable(
             "iron_{}_repl".format(ft), self.__nvim.current.buffer.number

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -60,7 +60,7 @@ class Iron(BaseIron):
         self.open_repl_for(self.prompt("repl type"))
 
     @neovim.command("IronRepl")
-    def get_repl(self):
+    def create_repl(self):
         self.open_repl_for(self.get_ft())
 
     @neovim.command("IronClearReplDefinition")

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -63,21 +63,33 @@ class Iron(object):
             repl['repl_id'], data
         ))
 
-        self.__nvim.call('jobsend', repl["repl_id"], data)
+        self.call('jobsend', repl["repl_id"], data)
 
     def set_repl_for_ft(self, ft):
         if ft not in self.__repl:
+            log.debug("Adding repl definition for {}".format(ft))
             self.__repl[ft] = self.get_repl_template(ft)
 
         return self.__repl[ft]
 
+    def clear_repl_for_ft(self, ft):
+        log.debug("clearing repl definitions for {}".format(ft))
+        for m in self.__repl[ft]['mappings']:
+            log.debug("unmapping keys {}".format(m))
+            self.call_cmd("umap {}".format(m))
+
+        del self.__repl[ft]
+
     def call_cmd(self, cmd):
+        log.debug("calling cmd {}".format(cmd))
         return self.__nvim.command(cmd)
 
     def call(self, cmd, *args):
+        log.debug("calling function {} with args {}".format(cmd, args))
         return self.__nvim.call(cmd, *args)
 
     def register(self, reg):
+        log.debug("getting register {}".format(reg))
         return self.__nvim.funcs.getreg(reg)
 
     def set_register(self, reg, data):
@@ -180,6 +192,14 @@ class Iron(object):
     @neovim.command("IronRepl")
     def get_repl(self):
         self.open_repl_for(self.get_ft())
+
+    @neovim.command("IronClearReplDefinition")
+    def clear_repl_definition(self):
+        self.clear_repl_for_ft(self.prompt("repl type"))
+
+    @neovim.command("IronClearReplDefinition")
+    def clear_repl_definition(self):
+        self.clear_repl_for_ft(self.get_ft())
 
     @neovim.function("IronSendSpecial")
     def mapping_send(self, args):

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -146,7 +146,7 @@ class Iron(object):
 
         log.info("got this hook function list: {}".format(hooks))
 
-        [self.call(i, curr_buf) for i in list()]
+        [self.call(i, curr_buf) for i in hooks]
 
     # Actual Fns
     def open_repl_for(self, ft):

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -109,12 +109,12 @@ class Iron(object):
     def get_list_variable(self, var):
         v = self.get_variable(var)
 
-        if var is None:
+        if v is None:
             return []
-        elif not isinstance(var, list):
-            return [var]
+        elif not isinstance(v, list):
+            return [v]
         else:
-            return var
+            return v
 
 
     def prompt(self, msg):

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -63,6 +63,10 @@ class Iron(BaseIron):
     def create_repl(self):
         self.open_repl_for(self.get_ft())
 
+    @neovim.command("IronDumpReplDefn")
+    def dump_repl_dict(self):
+        super().dump_repl_dict()
+
     @neovim.command("IronClearReplDefinition")
     def clear_repl_definition(self):
         self.clear_repl_for_ft(self.prompt("repl type"))

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -23,7 +23,7 @@ class Iron(BaseIron):
     # Actual Fns
     def open_repl_for(self, ft):
         log.info("Opening repl for {}".format(ft))
-        repl = self.set_repl_for_ft(ft)
+        repl = self.get_repl_for_ft(ft)
 
         if not repl:
             msg = "No repl found for {}".format(ft)

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -37,9 +37,6 @@ class Iron(BaseIron):
         self.call_hooks(ft)
         self.set_repl_id(ft, repl_id)
 
-        self.set_variable(
-            "iron_{}_repl".format(ft), self.__nvim.current.buffer.number
-        )
 
         return repl_id
 
@@ -87,7 +84,7 @@ class Iron(BaseIron):
         else:
             self.call_cmd("""normal! `[v`]"sy""")
 
-        return self.send_to_repl([self.__nvim.funcs.getreg('s')])
+        return self.send_to_repl([self.register('s')])
 
     @neovim.function("IronSend")
     def send_to_repl(self, args):

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -35,16 +35,15 @@ class Iron(BaseIron):
 
         self.set_mappings(repl, ft)
         self.call_hooks(ft)
+        self.set_repl_id(repl_id)
 
-        self.__repl[ft]['repl_id'] = repl_id
         self.set_variable(
             "iron_{}_repl".format(ft), self.__nvim.current.buffer.number
         )
 
         return repl_id
 
-    def sanitize_multiline(self, data):
-        repl = self.__repl.get(self.get_ft())
+    def sanitize_multiline(self, data, repl):
         multiline = repl['multiline']
         if "\n" in data and repl:
             if len(multiline) == 3:
@@ -92,7 +91,7 @@ class Iron(BaseIron):
 
     @neovim.function("IronSend")
     def send_to_repl(self, args):
-        repl = self.__repl.get(args[1]) if len(args) > 1 else None
+        repl = self.get_repl(args[1]) if len(args) > 1 else None
         repl = repl or self.get_current_repl()
 
         if not repl:
@@ -102,7 +101,7 @@ class Iron(BaseIron):
 
         if 'multiline' in repl:
             log.info("Multiline statement allowed - wrapping")
-            data, extra = self.sanitize_multiline(args[0])
+            data, extra = self.sanitize_multiline(args[0], repl)
         else:
             log.info("Plain string - no multiline")
             data = "{}\n".format(args[0])

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -44,7 +44,7 @@ class Iron(object):
 
     # Helper fns
     def termopen(self, cmd):
-        self.call_cmd('spl | wincmd j')
+        self.call_cmd('spl | wincmd j | enew')
 
         return self.call('termopen', cmd)
 

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -141,7 +141,7 @@ class Iron(object):
 
         hooks = (
             self.get_list_variable("iron_new_repl_hooks") +
-            self.has_variable('iron_new_{}_repl_hooks'.format(ft))
+            self.get_list_variable('iron_new_{}_repl_hooks'.format(ft))
         )
 
         [self.call(i, curr_buf) for i in list()]

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -144,6 +144,8 @@ class Iron(object):
             self.get_list_variable('iron_new_{}_repl_hooks'.format(ft))
         )
 
+        log.info("got this hook function list: {}".format(hooks))
+
         [self.call(i, curr_buf) for i in list()]
 
     # Actual Fns

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -8,145 +8,17 @@ Currently it keeps track of a single repl instance per filetype.
 """
 import logging
 import neovim
-from iron.repls import available_repls
+from iron.base import BaseIron
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+
 @neovim.plugin
-class Iron(object):
+class Iron(BaseIron):
 
     def __init__(self, nvim):
-        self.__nvim = nvim
-        self.__repl = {}
-
-        debug_path = (
-            'iron_debug' in nvim.vars and './.iron_debug.log'
-            or nvim.vars.get('iron_debug_path')
-        )
-
-        if debug_path is not None:
-            fh = logging.FileHandler(debug_path)
-            fh.setLevel(logging.DEBUG)
-            log.addHandler(fh)
-
-
-    def get_repl_template(self, ft):
-        repls = list(filter(
-            lambda k: ft == k['language'] and k['detect'](),
-            available_repls))
-
-        log.info('Got {} as repls for {}'.format(
-            [i['command'] for i in repls], ft
-        ))
-
-        return len(repls) and repls[0] or {}
-
-    # Helper fns
-    def termopen(self, cmd):
-        self.call_cmd('spl | wincmd j | enew')
-
-        return self.call('termopen', cmd)
-
-    def get_ft(self):
-        return self.__nvim.current.buffer.options["ft"]
-
-    def get_current_repl(self):
-        return self.__repl.get(self.get_ft())
-
-    def get_current_bindings(self):
-        return self.get_current_repl().get('fns', {})
-
-    def send_data(self, data, repl=None):
-        repl = repl or self.get_current_repl()
-        log.info('Sending data to repl ({}):\n{}'.format(
-            repl['repl_id'], data
-        ))
-
-        self.call('jobsend', repl["repl_id"], data)
-
-    def set_repl_for_ft(self, ft):
-        if ft not in self.__repl:
-            log.debug("Adding repl definition for {}".format(ft))
-            self.__repl[ft] = self.get_repl_template(ft)
-
-        return self.__repl[ft]
-
-    def clear_repl_for_ft(self, ft):
-        log.debug("clearing repl definitions for {}".format(ft))
-        for m in self.__repl[ft]['mappings']:
-            log.debug("unmapping keys {}".format(m))
-            self.call_cmd("umap {}".format(m))
-
-        del self.__repl[ft]
-
-    def call_cmd(self, cmd):
-        log.debug("calling cmd {}".format(cmd))
-        return self.__nvim.command(cmd)
-
-    def call(self, cmd, *args):
-        log.debug("calling function {} with args {}".format(cmd, args))
-        return self.__nvim.call(cmd, *args)
-
-    def register(self, reg):
-        log.debug("getting register {}".format(reg))
-        return self.__nvim.funcs.getreg(reg)
-
-    def set_register(self, reg, data):
-        log.info("Setting register '{}' with value '{}'".format(reg, data))
-        return self.__nvim.funcs.setreg(reg, data)
-
-    def set_variable(self, var, data):
-        log.info("Setting variable '{}' with value '{}'".format(var, data))
-        self.__nvim.vars[var] = data
-
-    def has_variable(self, var):
-        return var in self.__nvim.vars
-
-    def get_variable(self, var):
-        return self.__nvim.vars.get(var)
-
-    def get_list_variable(self, var):
-        v = self.get_variable(var)
-
-        if v is None:
-            return []
-        elif not isinstance(v, list):
-            return [v]
-        else:
-            return v
-
-
-    def prompt(self, msg):
-        self.call("inputsave")
-        ret = self.call("input", "iron> {}: ".format(msg))
-        self.call("inputrestore")
-        return ret
-
-    def set_mappings(self, repl, ft):
-        self.__repl[ft]['fns'] = {}
-        self.__repl[ft]['mappings'] = []
-        add_mappings = self.__repl[ft]['mappings'].append
-        base_cmd = 'nnoremap <silent> {} :call IronSendSpecial("{}")<CR>'
-
-        for k, n, c in repl.get('mappings', []):
-            log.info("Mapping '{}' to function '{}'".format(k, n))
-
-            self.call_cmd(base_cmd.format(k, n))
-            self.__repl[ft]['fns'][n] = c
-            add_mappings(k)
-
-    def call_hooks(self, ft):
-        curr_buf = self.__nvim.current.buffer.number
-
-        hooks = (
-            self.get_list_variable("iron_new_repl_hooks") +
-            self.get_list_variable('iron_new_{}_repl_hooks'.format(ft))
-        )
-
-        log.info("got this hook function list: {}".format(hooks))
-
-        [self.call(i, curr_buf) for i in hooks]
+        super().__init__(nvim)
 
     # Actual Fns
     def open_repl_for(self, ft):

--- a/rplugin/python3/iron/base.py
+++ b/rplugin/python3/iron/base.py
@@ -133,10 +133,16 @@ class BaseIron(object):
         self.call("inputrestore")
         return ret
 
+    def dump_repl_dict(self):
+        log.warning("#-- Dumping repl definitions --#")
+        log.warning(self.__repl)
+        log.warning("#--   End of repl def dump   --#")
+
     def set_mappings(self, repl, ft):
         self.__repl[ft]['fns'] = {}
         self.__repl[ft]['mappings'] = []
         add_mappings = self.__repl[ft]['mappings'].append
+
         base_cmd = 'nnoremap <silent> {} :call IronSendSpecial("{}")<CR>'
 
         for k, n, c in repl.get('mappings', []):

--- a/rplugin/python3/iron/base.py
+++ b/rplugin/python3/iron/base.py
@@ -1,0 +1,151 @@
+# encoding:utf-8
+""" iron.nvim (Interactive Repls Over Neovim).
+
+`iron` is a plugin that allows better interactions with interactive repls
+using neovim's job-control and terminal.
+
+Currently it keeps track of a single repl instance per filetype.
+"""
+import logging
+import neovim
+from iron.repls import available_repls
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+class BaseIron(object):
+
+    def __init__(self, nvim):
+        self.__nvim = nvim
+        self.__repl = {}
+
+        debug_path = (
+            'iron_debug' in nvim.vars and './.iron_debug.log'
+            or nvim.vars.get('iron_debug_path')
+        )
+
+        if debug_path is not None:
+            fh = logging.FileHandler(debug_path)
+            fh.setLevel(logging.DEBUG)
+            log.addHandler(fh)
+
+
+    def get_repl_template(self, ft):
+        repls = list(filter(
+            lambda k: ft == k['language'] and k['detect'](),
+            available_repls))
+
+        log.info('Got {} as repls for {}'.format(
+            [i['command'] for i in repls], ft
+        ))
+
+        return len(repls) and repls[0] or {}
+
+    # Helper fns
+    def termopen(self, cmd):
+        self.call_cmd('spl | wincmd j | enew')
+
+        return self.call('termopen', cmd)
+
+    def get_ft(self):
+        return self.__nvim.current.buffer.options["ft"]
+
+    def get_current_repl(self):
+        return self.__repl.get(self.get_ft())
+
+    def get_current_bindings(self):
+        return self.get_current_repl().get('fns', {})
+
+    def send_data(self, data, repl=None):
+        repl = repl or self.get_current_repl()
+        log.info('Sending data to repl ({}):\n{}'.format(
+            repl['repl_id'], data
+        ))
+
+        self.call('jobsend', repl["repl_id"], data)
+
+    def set_repl_for_ft(self, ft):
+        if ft not in self.__repl:
+            log.debug("Adding repl definition for {}".format(ft))
+            self.__repl[ft] = self.get_repl_template(ft)
+
+        return self.__repl[ft]
+
+    def clear_repl_for_ft(self, ft):
+        log.debug("clearing repl definitions for {}".format(ft))
+        for m in self.__repl[ft]['mappings']:
+            log.debug("unmapping keys {}".format(m))
+            self.call_cmd("umap {}".format(m))
+
+        del self.__repl[ft]
+
+    def call_cmd(self, cmd):
+        log.debug("calling cmd {}".format(cmd))
+        return self.__nvim.command(cmd)
+
+    def call(self, cmd, *args):
+        log.debug("calling function {} with args {}".format(cmd, args))
+        return self.__nvim.call(cmd, *args)
+
+    def register(self, reg):
+        log.debug("getting register {}".format(reg))
+        return self.__nvim.funcs.getreg(reg)
+
+    def set_register(self, reg, data):
+        log.info("Setting register '{}' with value '{}'".format(reg, data))
+        return self.__nvim.funcs.setreg(reg, data)
+
+    def set_variable(self, var, data):
+        log.info("Setting variable '{}' with value '{}'".format(var, data))
+        self.__nvim.vars[var] = data
+
+    def has_variable(self, var):
+        return var in self.__nvim.vars
+
+    def get_variable(self, var):
+        return self.__nvim.vars.get(var)
+
+    def get_list_variable(self, var):
+        v = self.get_variable(var)
+
+        if v is None:
+            return []
+        elif not isinstance(v, list):
+            return [v]
+        else:
+            return v
+
+
+    def prompt(self, msg):
+        self.call("inputsave")
+        ret = self.call("input", "iron> {}: ".format(msg))
+        self.call("inputrestore")
+        return ret
+
+    def set_mappings(self, repl, ft):
+        self.__repl[ft]['fns'] = {}
+        self.__repl[ft]['mappings'] = []
+        add_mappings = self.__repl[ft]['mappings'].append
+        base_cmd = 'nnoremap <silent> {} :call IronSendSpecial("{}")<CR>'
+
+        for k, n, c in repl.get('mappings', []):
+            log.info("Mapping '{}' to function '{}'".format(k, n))
+
+            self.call_cmd(base_cmd.format(k, n))
+            self.__repl[ft]['fns'][n] = c
+            add_mappings(k)
+
+    def call_hooks(self, ft):
+        curr_buf = self.__nvim.current.buffer.number
+
+        hooks = (
+            self.get_list_variable("iron_new_repl_hooks") +
+            self.get_list_variable('iron_new_{}_repl_hooks'.format(ft))
+        )
+
+        log.info("got this hook function list: {}".format(hooks))
+
+        [self.call(i, curr_buf) for i in hooks]
+
+

--- a/rplugin/python3/iron/base.py
+++ b/rplugin/python3/iron/base.py
@@ -77,6 +77,9 @@ class BaseIron(object):
 
     def set_repl_id(self, ft, repl_id):
         self.__repl[ft]['repl_id'] = repl_id
+        self.set_variable(
+            "iron_{}_repl".format(ft), self.__nvim.current.buffer.number
+        )
 
 
     def clear_repl_for_ft(self, ft):

--- a/rplugin/python3/iron/base.py
+++ b/rplugin/python3/iron/base.py
@@ -83,23 +83,23 @@ class BaseIron(object):
 
 
     def clear_repl_for_ft(self, ft):
-        log.debug("clearing repl definitions for {}".format(ft))
+        log.debug("Clearing repl definitions for {}".format(ft))
         for m in self.__repl[ft]['mappings']:
-            log.debug("unmapping keys {}".format(m))
+            log.debug("Unmapping keys {}".format(m))
             self.call_cmd("umap {}".format(m))
 
         del self.__repl[ft]
 
     def call_cmd(self, cmd):
-        log.debug("calling cmd {}".format(cmd))
+        log.debug("Calling cmd {}".format(cmd))
         return self.__nvim.command(cmd)
 
     def call(self, cmd, *args):
-        log.debug("calling function {} with args {}".format(cmd, args))
+        log.debug("Calling function {} with args {}".format(cmd, args))
         return self.__nvim.call(cmd, *args)
 
     def register(self, reg):
-        log.debug("getting register {}".format(reg))
+        log.debug("Getting register {}".format(reg))
         return self.__nvim.funcs.getreg(reg)
 
     def set_register(self, reg, data):
@@ -143,6 +143,9 @@ class BaseIron(object):
         self.__repl[ft]['mappings'] = []
         add_mappings = self.__repl[ft]['mappings'].append
 
+        log.info("Mapping special functions for {}".format(ft))
+        log.debug("Available mappings are: {}".format(repl.get("mappings")))
+
         base_cmd = 'nnoremap <silent> {} :call IronSendSpecial("{}")<CR>'
 
         for k, n, c in repl.get('mappings', []):
@@ -160,7 +163,7 @@ class BaseIron(object):
             self.get_list_variable('iron_new_{}_repl_hooks'.format(ft))
         )
 
-        log.info("got this hook function list: {}".format(hooks))
+        log.info("Got this hook function list: {}".format(hooks))
 
         [self.call(i, curr_buf) for i in hooks]
 

--- a/rplugin/python3/iron/base.py
+++ b/rplugin/python3/iron/base.py
@@ -51,8 +51,11 @@ class BaseIron(object):
     def get_ft(self):
         return self.__nvim.current.buffer.options["ft"]
 
+    def get_repl(self, ft):
+        return self.__repl.get(ft)
+
     def get_current_repl(self):
-        return self.__repl.get(self.get_ft())
+        return self.get_repl(self.get_ft())
 
     def get_current_bindings(self):
         return self.get_current_repl().get('fns', {})
@@ -71,6 +74,10 @@ class BaseIron(object):
             self.__repl[ft] = self.get_repl_template(ft)
 
         return self.__repl[ft]
+
+    def set_repl_id(self, ft, repl_id):
+        self.__repl[ft]['repl_id'] = repl_id
+
 
     def clear_repl_for_ft(self, ft):
         log.debug("clearing repl definitions for {}".format(ft))

--- a/rplugin/python3/iron/base.py
+++ b/rplugin/python3/iron/base.py
@@ -68,9 +68,9 @@ class BaseIron(object):
 
         self.call('jobsend', repl["repl_id"], data)
 
-    def set_repl_for_ft(self, ft):
+    def get_repl_for_ft(self, ft):
         if ft not in self.__repl:
-            log.debug("Adding repl definition for {}".format(ft))
+            log.debug("Getting repl definition for {}".format(ft))
             self.__repl[ft] = self.get_repl_template(ft)
 
         return self.__repl[ft]
@@ -84,7 +84,7 @@ class BaseIron(object):
 
     def clear_repl_for_ft(self, ft):
         log.debug("Clearing repl definitions for {}".format(ft))
-        for m in self.__repl[ft]['mappings']:
+        for m in self.__repl[ft]['mapped_keys']:
             log.debug("Unmapping keys {}".format(m))
             self.call_cmd("umap {}".format(m))
 
@@ -140,8 +140,8 @@ class BaseIron(object):
 
     def set_mappings(self, repl, ft):
         self.__repl[ft]['fns'] = {}
-        self.__repl[ft]['mappings'] = []
-        add_mappings = self.__repl[ft]['mappings'].append
+        self.__repl[ft]['mapped_keys'] = []
+        add_mappings = self.__repl[ft]['mapped_keys'].append
 
         log.info("Mapping special functions for {}".format(ft))
         log.debug("Available mappings are: {}".format(repl.get("mappings")))


### PR DESCRIPTION
Not targeting anything specific here yet, but this should improve a bit REPL management.

As a bonus, this allows `hooks` to be executed after repl started by setting a list of hooks on `iron_new_repl_hooks` and `iron_new_<ft>_repl_hooks` (for specific `ft`). This list of functions should receive the buffer number only.