### PR TITLE
Fix the single line problem in the ptipython repl

### DIFF
--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -46,7 +46,7 @@ class Iron(BaseIron):
             return ("{}{}{}".format(pre, data, post), extra)
 
         logger.info("String was not multiline. Continuing")
-        return (data, None)
+        return ("{}\n".format(data), None)
 
     def get_or_prompt_ft(self):
         ft = self.get_ft()


### PR DESCRIPTION
Adding a new line char for the multiline compatible REPL in case the data is a single line. This solved the last comment of issue #4 and should not mess with the other repl (did not check it though) but based on line 138 of __init.py__ it should work. 