### PR TITLE
Check if ipython exists before trying to open a ptpipython session

### DIFF
--- a/rplugin/python3/iron/repls/python.py
+++ b/rplugin/python3/iron/repls/python.py
@@ -39,5 +39,5 @@ ptipython = {
     'command': 'ptipython',
     'language': 'python',
     'multiline': ('\x1b[200~', '\x1b[201~', '\r'),
-    'detect': detect_fn('ptipython'),
+    'detect': detect_fn('ptipython') and detect_fn('ipython'),
 }


### PR DESCRIPTION
Having ptpython installed would cause iron.vim to cascade to ptipython mode, even if ipython was not installed.