### PR TITLE
Add support for alternative multline style

### DIFF
--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -24,14 +24,18 @@ class Iron(BaseIron):
     def sanitize_multiline(self, data, repl):
         multiline = repl['multiline']
         if "\n" in data and repl:
-            if len(multiline) == 3:
+            if len(multiline) == 4:
+                (pre, post, extra, nline) = multiline
+            elif len(multiline) == 3:
                 (pre, post, extra) = multiline
+                nline = '\n'
             else:
                 (pre, post) = multiline
+                nline = '\n'
                 extra = None
 
             logger.info("Multinine string supplied.")
-            return ("{}{}{}".format(pre, data, post), extra)
+            return ("{}{}{}".format(pre, data.replace('\n', nline), post), extra)
 
         logger.info("String was not multiline. Continuing")
         return ("{}\n".format(data), None)

--- a/rplugin/python3/iron/repls/elm.py
+++ b/rplugin/python3/iron/repls/elm.py
@@ -5,5 +5,6 @@ from iron.repls.utils.cmd import detect_fn
 repl = {
     'command': 'elm-repl',
     'language': 'elm',
-    'detect': detect_fn('elm-repl')
+    'detect': detect_fn('elm-repl'),
+    'multiline' : ('', '', '\n', '\\\n')
 }


### PR DESCRIPTION
Hi,

I'm not an expert on escape sequences, but as far as I know, the only way to do multiline statements with the Elm REPL is with a `\` before each carriage return. Maybe this is the case with other REPLs, too?

This PR adds another (4-tuple) way of defining how to handle multiline pastes to REPLs, the fourth element being what to swap the newline out for.

I hope it's clear enough from my code what I'm trying to achieve, if I'm doing it a silly way, please let me know 😃 