### PR TITLE
Adding support for Haskell

### DIFF
--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -39,6 +39,9 @@ Currently, Iron has support for the following programming languages:
     - lein
   - elixir
   - erlang
+  - haskell
+    - stack ghci
+    - ghci
   - lua
   - ocaml
   - python

--- a/rplugin/python3/iron/repls/__init__.py
+++ b/rplugin/python3/iron/repls/__init__.py
@@ -4,6 +4,7 @@ import iron.repls.clojure
 import iron.repls.elm
 import iron.repls.elixir
 import iron.repls.erlang
+import iron.repls.haskell
 import iron.repls.lua
 import iron.repls.lisp
 import iron.repls.ocaml
@@ -24,6 +25,8 @@ available_repls = [
     elm.repl,
     elixir.repl,
     erlang.repl,
+    haskell.stackghci,
+    haskell.ghci,
     lua.repl,
     lisp.sbcl,
     lisp.clisp,

--- a/rplugin/python3/iron/repls/haskell.py
+++ b/rplugin/python3/iron/repls/haskell.py
@@ -1,0 +1,15 @@
+# encoding:utf-8
+"""Haskell repl definitions for iron.nvim. """
+from iron.repls.utils.cmd import detect_fn
+
+ghci = {
+    'command': 'ghci',
+    'language': 'haskell',
+    'detect': detect_fn('ghci'),
+}
+
+stackghci = {
+    'command': 'stack ghci',
+    'language': 'haskell',
+    'detect': detect_fn('stack'),
+}


### PR DESCRIPTION
This PR adds REPL definitions for two Haskell REPLs: [Stack's GHCi](https://docs.haskellstack.org/en/stable/ghci/), and [vanilla GHCi](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html). More options could be added in the future - for example, adding a REPL that launches with [Intero](https://github.com/commercialhaskell/intero) loaded, adding custom actions, etc. However, basic REPL inclusion is nice to have for now.

Please let me know if there are any other changes which should be made (i.e. tests, etc.). The changes in this PR simply (1) add the REPL definitions and (2) modify the docs to indicate that some Haskell support is available. I have tested the definitions manually, but not attempted any sort of automatic testing.