### PR TITLE
Turn ctr and cp into <Plug> mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ other combination of commands/mappings you may need to send text to the repl.
 Iron has also set conveniently a mapping for calling back the previous command:
 `cp` (remember as call previous).
 
+Both `ctr` and `cp` can be remmaped, for example to define them only for the
+python filetype:
+
+```vim
+augroup ironmapping
+    autocmd!
+    autocmd Filetype python nmap <buffer> <localleader>t <Plug>(iron-send-motion)
+    autocmd Filetype python vmap <buffer> <localleader>t <Plug>(iron-send-motion)
+    autocmd Filetype python nmap <buffer> <localleader>p <Plug>(iron-repeat-cmd)
+augroup END
+```
+
 Iron also can have special, language/repl based mappings as defined per-repl.
 Refer to Language Special Mappings above for more information.
 

--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -111,6 +111,20 @@ Mappings                                                        *iron-mappings*
 ~all languages~
 ctr
   send a chunk of text to REPL. Works with motions.
+cp
+  repeat the previous command
+
+Those hereabove mappings can be redefined by the user, i.e: >
+
+  nmap <localleader>t <Plug>(iron-send-motion)
+<
+
+  -------------------------------------------------------------~
+   LHS(default)     RHS                                  MODE~
+  -------------------------------------------------------------~
+   ctr              |<Plug>(iron-send-motion)|              `nv`
+   cp               |<Plug>(iron-repeat-cmd|                `n`
+  -------------------------------------------------------------~
 
 ~clojure~
 <leader>so

--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -1,4 +1,22 @@
-nmap <silent> ctr :set opfunc=IronSendMotion<CR>g@
-vmap <silent> ctr :call IronSendMotion('visual')<CR>
+nnoremap <silent> <Plug>(iron-send-motion)
+      \ :<c-u>set opfunc=IronSendMotion<CR>g@
+vnoremap <silent> <Plug>(iron-send-motion)
+      \ :<c-u>call IronSendMotion('visual')<CR>
 "Call previous command again
-nmap <silent> cp :call IronSend("\u001b\u005b\u0041")<CR>
+nnoremap <silent> <Plug>(iron-repeat-cmd)
+      \ :<c-u>call IronSend("\u001b\u005b\u0041")<CR>
+
+if !hasmapto('<Plug>(iron-send-motion)')
+  if maparg('c','n') ==# ''
+    nmap ctr <Plug>(iron-send-motion)
+  endif
+  if maparg('c','v') ==# ''
+    vmap ctr <Plug>(iron-send-motion)
+  endif
+endif
+
+if !hasmapto('<Plug>(iron-repeat-cmd)')
+  if maparg('c','n') ==# ''
+    nmap cp <Plug>(iron-repeat-cmd)
+  endif
+endif


### PR DESCRIPTION
- Allow the user to define his own mappings `ctr` and `cp` in his vimrc
- If the user did not define his own mappings, default to `ctr` and `cp`
  mappings, only if `c` is not already mapped. See
  https://github.com/tpope/vim-commentary/commit/be7903
- Vim documentation has been updated to explain the new <Plug> mappings
- README.md has been updated to mention how to use the new <Plug>
  mappings.
- Possible issue ?: the <plug> mappings are globally defined whereas
  they should only be defined for the filetype repl (i.e. python,
  elixir, elm, ...)