### PR TITLE
Fix cursor without marks

### DIFF
--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -1,7 +1,7 @@
 nnoremap <silent> <Plug>(iron-send-motion)
-      \ mx:<c-u>set opfunc=IronSendMotion<CR>g@
+      \ :<c-u>let b:iron_cursor_pos = winsaveview()<CR>:<c-u>set opfunc=IronSendMotion<CR>g@
 vnoremap <silent> <Plug>(iron-send-motion)
-      \ mx:<c-u>call IronSendMotion('visual')<CR>
+      \ :<c-u>let b:iron_cursor_pos = winsaveview()<CR>:<c-u>call IronSendMotion('visual')<CR>
 "Call previous command again
 nnoremap <silent> <Plug>(iron-repeat-cmd)
       \ :<c-u>call IronSend("\u001b\u005b\u0041")<CR>

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -117,9 +117,7 @@ class Iron(BaseIron):
             init = self.nvim.current.buffer.mark('[')
             end = self.nvim.current.buffer.mark(']')
 
-        prev = self.nvim.current.buffer.mark("x")
         end[1] += 1
-        prev[1] += 1
 
         text = self.nvim.current.buffer[init[0]-1:end[0]]
 
@@ -135,7 +133,11 @@ class Iron(BaseIron):
 
             logger.debug("Stripped: {}".format("\n".join(text)))
 
-        self.nvim.funcs.cursor(prev)
+        try:
+          self.nvim.call('winrestview', self.nvim.eval('b:iron_cursor_pos'))
+        # in case key not found
+        except NvimError:
+            pass
 
         return self.send_to_repl(["\n".join(text)])
 


### PR DESCRIPTION
Use `winrestview`. It uppers that `winsaveview` must be called before
the `operatorfunc` is or else the cursor jumps and the *new* position is
saved.