### PR TITLE
Add REPL for Racket

### DIFF
--- a/rplugin/python3/iron/repls/__init__.py
+++ b/rplugin/python3/iron/repls/__init__.py
@@ -1,21 +1,22 @@
 # encoding:utf-8
 """General repl definitions for iron.nvim. """
 import iron.repls.clojure
-import iron.repls.elm
 import iron.repls.elixir
+import iron.repls.elm
 import iron.repls.erlang
 import iron.repls.haskell
-import iron.repls.lua
 import iron.repls.lisp
-import iron.repls.ocaml
-import iron.repls.python
-import iron.repls.pure
+import iron.repls.lua
 import iron.repls.node
+import iron.repls.ocaml
+import iron.repls.pure
+import iron.repls.python
+import iron.repls.r
+import iron.repls.racket
 import iron.repls.ruby
 import iron.repls.scala
 import iron.repls.scheme
 import iron.repls.sh
-import iron.repls.r
 import iron.repls.tcl
 
 available_repls = [
@@ -45,6 +46,7 @@ available_repls = [
     scala.scala,
     scheme.repl,
     r.repl,
+    racket.repl,
     tcl.repl,
     sh.zsh_zsh,
     sh.zsh_sh,

--- a/rplugin/python3/iron/repls/racket.py
+++ b/rplugin/python3/iron/repls/racket.py
@@ -1,0 +1,9 @@
+# encoding:utf-8
+"""Scheme repl definitions for iron.nvim. """
+from iron.repls.utils.cmd import detect_fn
+
+repl = {
+    'command': 'racket',
+    'language': 'racket',
+    'detect': detect_fn('racket')
+}


### PR DESCRIPTION
This change set adds a REPL definition for Racket. I've tested it to work on my machine; it's basically identical to the Scheme definition, but using a different command and filetype.

I also sorted the imports in the `__init__.py` file; I can undo this if it is not desirable.