### PR TITLE
Don't restore view after iron-send-motion.

### DIFF
--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -1,7 +1,7 @@
 nnoremap <silent> <Plug>(iron-send-motion)
-      \ :<c-u>let b:iron_cursor_pos = winsaveview()<CR>:<c-u>set opfunc=IronSendMotion<CR>g@
+      \ :<c-u>set opfunc=IronSendMotion<CR>g@
 vnoremap <silent> <Plug>(iron-send-motion)
-      \ :<c-u>let b:iron_cursor_pos = winsaveview()<CR>:<c-u>call IronSendMotion('visual')<CR>
+      \ :<c-u>call IronSendMotion('visual')<CR>
 
 "Call previous command again
 nnoremap <silent> <Plug>(iron-repeat-cmd) :call IronSend("\u001b\u005b\u0041")<CR>

--- a/rplugin/python3/iron/__init__.py
+++ b/rplugin/python3/iron/__init__.py
@@ -133,12 +133,6 @@ class Iron(BaseIron):
 
             logger.debug("Stripped: {}".format("\n".join(text)))
 
-        try:
-          self.nvim.call('winrestview', self.nvim.eval('b:iron_cursor_pos'))
-        # in case key not found
-        except NvimError:
-            pass
-
         return self.send_to_repl(["\n".join(text)])
 
     @neovim.function("IronSend")


### PR DESCRIPTION
Fixes #50.

b:iron_cursor_pos is not updated consistently and restoring the view
does not appear to be necessary anyway.

This fixes repeating iron-send-motion command with `.`; previously
repeating the command would move your cursor to the location of the
previous command.