### PR TITLE
Attempt to fix mappings

### DIFF
--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -4,23 +4,18 @@ vnoremap <silent> <Plug>(iron-send-motion)
       \ :<c-u>let b:iron_cursor_pos = winsaveview()<CR>:<c-u>call IronSendMotion('visual')<CR>
 
 "Call previous command again
-nnoremap <silent> <Plug>(iron-repeat-cmd) :call IronSend("\u001b\u005b\u0041")<CR>
-nnoremap <silent> <Plug>(iron-cr)         :call IronSend("")<CR> " <CR> to force execution of command
-nnoremap <silent> <Plug>(iron-interrupt)  :call IronSend("\u0003")<CR> " <c-c> to interrupt command
-nnoremap <silent> <Plug>(iron-exit)       :call IronSend("\u0004")<CR> " <c-d> to exit iron
-nnoremap <silent> <Plug>(iron-clear)      :call IronSend("\u000C")<CR> " <c-l> to clear screen
+map <silent> <Plug>(iron-repeat-cmd) :call IronSend("\u001b\u005b\u0041")<CR>
+map <silent> <Plug>(iron-cr)         :call IronSend("")<CR>                   " <CR> to force execution of command
+map <silent> <Plug>(iron-interrupt)  :call IronSend("\u0003")<CR>             " <c-c> to interrupt command
+map <silent> <Plug>(iron-exit)       :call IronSend("\u0004")<CR>             " <c-d> to exit iron
+map <silent> <Plug>(iron-clear)      :call IronSend("\u000C")<CR>             " <c-l> to clear screen
 
-if !hasmapto('<Plug>(iron-send-motion)')
-  if maparg('c','n') ==# ''
-    nmap ctr <Plug>(iron-send-motion)
-  endif
-  if maparg('c','v') ==# ''
-    vmap ctr <Plug>(iron-send-motion)
-  endif
+if !exists('g:iron_map_defaults')
+  let g:iron_map_defaults = 1
 endif
 
-if !hasmapto('<Plug>(iron-repeat-cmd)')
-  if maparg('c','n') ==# ''
-    nmap cp <Plug>(iron-repeat-cmd)
-  endif
+if g:iron_map_defaults
+    nnoremap ctr <Plug>(iron-send-motion)
+    vnoremap ctr <Plug>(iron-send-motion)
+    nnoremap cp <Plug>(iron-repeat-cmd)
 endif

--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -1,6 +1,6 @@
-nnoremap <silent> <Plug>(iron-send-motion)
+map <silent> <Plug>(iron-send-motion)
       \ :<c-u>let b:iron_cursor_pos = winsaveview()<CR>:<c-u>set opfunc=IronSendMotion<CR>g@
-vnoremap <silent> <Plug>(iron-send-motion)
+vmap <silent> <Plug>(iron-send-motion)
       \ :<c-u>let b:iron_cursor_pos = winsaveview()<CR>:<c-u>call IronSendMotion('visual')<CR>
 
 "Call previous command again


### PR DESCRIPTION
Attempt to fix mappings by always mapping them unless explicitly stating.

This is better than defining once.

Should fix #49.

Also, makes `<Plug>` mappings recursive. Non-recursive mappings should be local to your init.vim when defining a map that uses it.