### PR TITLE
Restore winsaveview

### DIFF
--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -1,5 +1,7 @@
-map <silent> <Plug>(iron-send-motion) :<c-u>set opfunc=IronSendMotion<CR>g@
-vmap <silent> <Plug>(iron-send-motion) :<c-u>call IronSendMotion('visual')<CR>
+map <silent> <Plug>(iron-send-motion) 
+      \ :<c-u>let b:iron_cursor_pos = winsaveview() \| set opfunc=IronSendMotion<CR>g@
+vmap <silent> <Plug>(iron-send-motion)
+      \ :<c-u>let b:iron_cursor_pos = winsaveview() \| call IronSendMotion('visual')<CR>
 
 "Call previous command again
 map <silent> <Plug>(iron-repeat-cmd) :call IronSend("\u001b\u005b\u0041")<CR>

--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -15,7 +15,7 @@ if !exists('g:iron_map_defaults')
 endif
 
 if g:iron_map_defaults
-    nnoremap ctr <Plug>(iron-send-motion)
-    vnoremap ctr <Plug>(iron-send-motion)
-    nnoremap cp <Plug>(iron-repeat-cmd)
+    nmap ctr <Plug>(iron-send-motion)
+    vmap ctr <Plug>(iron-send-motion)
+    nmap cp <Plug>(iron-repeat-cmd)
 endif


### PR DESCRIPTION
Refer #51.

This reenables the previous behavior, which is unfortunately bad to repeat.

It seems that marks are the best option.