### PR TITLE
Add `IronWatchFile` and `IronUnwatchFile`

### DIFF
--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -19,3 +19,16 @@ if g:iron_map_defaults
     vmap ctr <Plug>(iron-send-motion)
     nmap cp <Plug>(iron-repeat-cmd)
 endif
+
+function! IronWatchFile(fname, command) abort
+  augroup IronWatch
+    exec "autocmd BufWritePost ".a:fname." call IronSend('".a:command."')"
+  augroup END
+endfunction
+
+function! IronUnwatchFile(fname) abort
+  exec "autocmd! IronWatch BufWritePost" . a:fname
+endfunction
+
+command! -nargs=* IronWatchCurrentFile call IronWatchFile(expand('%'), <q-args>)
+command! -nargs=* IronUnwatchCurrentFile call IronUnwatchFile(expand('%'))


### PR DESCRIPTION
These are convenience functions added so data can be send to repls every
time a file is saved. While other approaches might be better (such as
setting up jobcontrol or make), sometimes this is just enough.