### PR TITLE
Add g:iron_map_defaults to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ other combination of commands/mappings you may need to send text to the repl.
 Iron has also set conveniently a mapping for calling back the previous command:
 `cp` (remember as call previous).
 
-Both `ctr` and `cp` can be remmaped, for example to define them only for the
-python filetype:
+Both `ctr` and `cp` can be remmaped. For example, if you only work with python,
+you can use the following configuration:
 
 ```vim
+" deactivate default mappings
+let g:iron_map_defaults=0
+" define custom mappings for the python filetype
 augroup ironmapping
     autocmd!
     autocmd Filetype python nmap <buffer> <localleader>t <Plug>(iron-send-motion)

--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -125,6 +125,10 @@ g:iron_new_REPL_hooks
 g:iron_new_`ft`_REPL_hooks
   Provide specific functions to be executed after a REPL of given ft is opened.
 
+g:iron_map_defaults
+  Provide default global mappings (see |iron-mappings|) to send a chunk of text
+  to a REPL (ctr) and to repeat the previous command (cp). Default value = 1.
+  
 ===============================================================================
 Mappings                                                        *iron-mappings*
 


### PR DESCRIPTION
Added the g:iron_map_defaults variable to the Customizing section of the
documentation.
Updated the README.md exemple to include g:iron_map_defaults (+ some
rewording of a sentence)