### PR TITLE
Fixed incorrect reference to customization variables in the help text.

### DIFF
--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -116,14 +116,17 @@ Customizing                                                  *iron-customizing*
 
 To change iron's behavior, change the following variables:
 
-g:iron_REPL_open_cmd
-  Allows REPL to be positioned differently.
+g:iron_repl_open_cmd
+  Allows REPL to be positioned differently. To open in a vertical split,
+  set this to "vsplit", for example.
 
-g:iron_new_REPL_hooks
+g:iron_new_repl_hooks
   List of functions to be executed after any REPL is opened.
 
-g:iron_new_`ft`_REPL_hooks
+g:iron_new_`ft`_repl_hooks
   Provide specific functions to be executed after a REPL of given ft is opened.
+  Here, `ft` should be replaced by the intended filetype, eg. 'python'
+  (without the quotes).
 
 g:iron_map_defaults
   Provide default global mappings (see |iron-mappings|) to send a chunk of text


### PR DESCRIPTION
I found that adjusting the variable `g:iron_REPL_open_cmd` given in `doc/iron.txt` (line 119) did not change the way the terminal opened. The variable is referenced in `rplugin/python3/iron/base.py` (on lines 84 and 323). However, all letters are lower case in that file. Setting the variable using all lowercase letters then allowed me to change the position of the window as desired. I found that the same was true for some of the other customization variables, which I changed as well.
I corrected this in the help text and added some basic instructions that I would have found useful.