### PR TITLE
Replace empty lines with the indentation from the previous line before sending to the REPL

### DIFF
--- a/lua/iron/init.lua
+++ b/lua/iron/init.lua
@@ -173,6 +173,14 @@ iron.ll.send_to_repl = function(ft, data)
   local window = vim.fn.win_getid(vim.fn.bufwinnr(mem.bufnr))
   vim.api.nvim_win_set_cursor(window, {vim.api.nvim_buf_line_count(mem.bufnr), 0})
 
+  local indent = ""
+  for i, v in ipairs(dt) do
+    if #v == 0 then
+      dt[i] = indent
+    else
+      indent = string.match(v, '^(%s)') or ""
+    end
+  end
   vim.api.nvim_call_function('chansend', {mem.job, dt})
 end
 


### PR DESCRIPTION
The Python REPL interprets an empty line as the termination of inputs,
so this is needed to tell it we might not be done with the input, e.g.

```python
class Something:
    b = 1

    # python repl will interpret the previous empty line as the end of the class
    # thus the method definition below will error
    def method():
        return self.b
```

I chose to implement it here because other REPLs might do the same