### PR TITLE
Account for changes to neovim API.

### DIFF
--- a/lua/iron/init.lua
+++ b/lua/iron/init.lua
@@ -117,7 +117,12 @@ iron.ll.create_new_repl = function(ft, repl, new_win)
   if new_win then
     winid = iron.ll.new_repl_window(bufnr, ft)
   else
-    winid = iron.ll.get(ft).winid
+    if iron.ll.get(ft) == nil then
+      winid = vim.api.nvim_get_current_win()
+      vim.api.nvim_win_set_buf(winid, bufnr)
+    else
+      winid = iron.ll.get(ft).winid
+    end
   end
 
   vim.api.nvim_set_current_win(winid)

--- a/lua/iron/init.lua
+++ b/lua/iron/init.lua
@@ -332,16 +332,18 @@ iron.core.send_line = function()
 end
 
 iron.core.send_chunk = function(mode, mtype)
-  local bstart, bend
+  local bstart, bend, bdelta
   local ft = iron.ll.get_buffer_ft(0)
   if ft == nil then return end
 
   if mode == "visual" then
     bstart = "'<"
     bend = "'>"
+    bdelta = 0
   else
     bstart = "'["
     bend = "']"
+    bdelta = 1
   end
 
   -- getpos is 1-based
@@ -385,7 +387,7 @@ iron.core.send_chunk = function(mode, mtype)
   vim.api.nvim_buf_set_extmark(
     0,
     iron.namespace,
-    b_line - 2,
+    b_line - 1 - bdelta,
     b_col - 1,
     {id = iron.mark.begin_last}
   )

--- a/lua/iron/init.lua
+++ b/lua/iron/init.lua
@@ -374,30 +374,28 @@ iron.core.send_chunk = function(mode, mtype)
 
   iron.core.send(ft, lines)
 
-  local mark = vim.api.nvim_buf_get_extmark_by_id(0, iron.namespace, iron.mark.save_pos)
+  local mark = vim.api.nvim_buf_get_extmark_by_id(0, iron.namespace, iron.mark.save_pos, {})
 
   if #mark ~= 0 then
     -- winrestview is 1-based
     vim.fn.winrestview({lnum = mark[1] + 1, col = mark[2] + 1})
-    vim.api.nvim_buf_del_extmark(0, iron.namespace, 20)
+    vim.api.nvim_buf_del_extmark(0, iron.namespace, iron.mark.save_pos)
   end
 
   vim.api.nvim_buf_set_extmark(
     0,
     iron.namespace,
-    iron.mark.begin_last,
-    b_line - 1,
+    b_line - 2,
     b_col - 1,
-    {}
+    {id = iron.mark.begin_last}
   )
 
   vim.api.nvim_buf_set_extmark(
     0,
     iron.namespace,
-    iron.mark.end_last,
     e_line - 1,
     e_col -1,
-    {}
+    {id = iron.mark.end_last}
   )
 
 end
@@ -413,8 +411,8 @@ iron.core.repeat_cmd = function()
   local b_line, b_col, e_line, e_col
 
   -- extmark is 0-based index
-  b_line, b_col = unpack(vim.api.nvim_buf_get_extmark_by_id(0, iron.namespace, iron.mark.begin_last))
-  e_line, e_col = unpack(vim.api.nvim_buf_get_extmark_by_id(0, iron.namespace, iron.mark.end_last))
+  b_line, b_col = unpack(vim.api.nvim_buf_get_extmark_by_id(0, iron.namespace, iron.mark.begin_last, {}))
+  e_line, e_col = unpack(vim.api.nvim_buf_get_extmark_by_id(0, iron.namespace, iron.mark.end_last, {}))
 
   local lines = vim.api.nvim_buf_get_lines(0, b_line, e_line + 1, 0)
 

--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -4,7 +4,7 @@ function! s:save_pos()
   "Indexes from winsaveview are 1-based
   "extmark is 0-based
 
-  call nvim_buf_set_extmark(0, nvim_create_namespace('iron'), 20, s:view.lnum - 1, s:view.col - 1, {})
+  call nvim_buf_set_extmark(0, nvim_create_namespace('iron'), s:view.lnum - 1, s:view.col - 1, {'id': 20})
 endfunction
 
 function! s:ironSendMotion(mode)


### PR DESCRIPTION
It looks like the number of arguments for:
- `nvim_buf_get_extmark_by_id`
- `nvim_buf_set_extmark`

has changed in a recent release of neovim. This is breaking the plugin for me and another users as described in issues #168 and #167.

I have also fixed an off-by-one error  in line 388 of `init.lua`. The starting mark was set a line too late.