### PR TITLE
Fix vim.api.nvim__set_hl_ns

### DIFF
--- a/lua/iron/marks.lua
+++ b/lua/iron/marks.lua
@@ -6,7 +6,7 @@ vim.api.nvim_set_hl(config.namespace, "IronLastSent", {
     bold = true
   })
 
-vim.api.nvim_set_hl_ns(config.namespace)
+vim.api.nvim__set_hl_ns(config.namespace)
 
 marks.set = function(opts)
   local extmark_config = {


### PR DESCRIPTION
nvim_set_hl_ns is actually spelled as nvim__set_hl_ns

neovim/neovim@bb6d2c9b7c92150c631068fcc0221fabb50aae5c