### PR TITLE
Fix off-by-one error when setting extmark

### DIFF
--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -1,7 +1,7 @@
 function! s:save_pos()
   let s:view = winsaveview()
 
-  call nvim_buf_set_extmark(0, nvim_create_namespace('iron'), s:view.lnum, s:view.col, {'id': 20})
+  call nvim_buf_set_extmark(0, nvim_create_namespace('iron'), s:view.lnum - 1, s:view.col, {'id': 20})
 endfunction
 
 function! s:ironSendMotion(mode)


### PR DESCRIPTION
The `winsaveview()` function returns 1-based index for _lnum_ and 0-based index for `col`.

This PR fixes the line number for `nvim_buf_set_extmark`, which expects 0-based index for both the line number and column number.