### PR TITLE
fix: end_col is 1-indexed while to_col is 0-indexed

### DIFF
--- a/lua/iron/marks.lua
+++ b/lua/iron/marks.lua
@@ -14,7 +14,7 @@ marks.set = function(opts)
     id = config.mark.send,
     -- to_line can be ignored if it's single line
     end_line = opts.to_line or opts.from_line,
-    end_col = opts.to_col
+    end_col = opts.to_col + 1
   }
 
   if opts.hl ~= nil then
@@ -54,7 +54,7 @@ marks.get = function()
     from_line = mark_pos[1],
     from_col = mark_pos[2],
     to_line = mark_pos[3].end_row,
-    to_col = mark_pos[3].end_col
+    to_col = mark_pos[3].end_col - 1
   }
 
 end


### PR DESCRIPTION
When selecting lines and a newline (the last line's length is zero), visual send fails with error:

```
E5108: Error executing lua .../nvim/site/pack/local/start/iron.nvim/lua/iron/marks.lua:33: end_col value outside range
stack traceback:
        [C]: in function 'nvim_buf_set_extmark'
        .../nvim/site/pack/local/start/iron.nvim/lua/iron/marks.lua:33: in function 'set'
        ...e/nvim/site/pack/local/start/iron.nvim/lua/iron/core.lua:193: in function 'send_chunk'
        ...e/nvim/site/pack/local/start/iron.nvim/lua/iron/core.lua:207: in function 'visual_send'
        [string ":lua"]:1: in main chunk
```

This PR could fix this.