### PR TITLE
Feat: add the 'buflisted' options for the repl buffer.

### DIFF
--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -251,6 +251,9 @@ The keys for configuring iron are the following:
 * `repl_open_cmd`:
   Command to be run when creating a new window for the repl.
   It can be a string or a function.
+* `buflisted`:
+  Whether should set the repl buffer to be "buflisted",
+  see |:h buflisted| for further details. Default: false.
 
 An example of configuration would be the following:
 

--- a/lua/iron/defaults.lua
+++ b/lua/iron/defaults.lua
@@ -16,6 +16,7 @@ local defaults = {
     begin_last = 99, -- Deprecated
     end_last = 100 -- Deprecated
   },
+  buflisted = false,
 }
 
 return setmetatable({

--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -65,7 +65,7 @@ ll.create_new_repl = function(ft, repl, new_win)
 
   local winid
   local prevwin = vim.api.nvim_get_current_win()
-  local bufnr = vim.api.nvim_create_buf(false, true)
+  local bufnr = vim.api.nvim_create_buf(config.buflisted, true)
 
   if new_win then
     winid = ll.new_repl_window(bufnr, ft)


### PR DESCRIPTION
By default, the repl buffer created by iron is not "buflisted".
I use the buffer functionality a lot, and I would like the REPL buffer
is nothing different with my other buffers.