### PR TITLE
feat: Add support for Stata

### DIFF
--- a/lua/iron/fts/init.lua
+++ b/lua/iron/fts/init.lua
@@ -27,6 +27,7 @@ local fts = {
   scala = require("iron.fts.scala"),
   scheme = require("iron.fts.scheme"),
   sh = require("iron.fts.sh"),
+  stata = require("iron.fts.stata"),
   tcl = require("iron.fts.tcl"),
   typescript = require("iron.fts.typescript"),
   zsh = require("iron.fts.zsh")

--- a/lua/iron/fts/stata.lua
+++ b/lua/iron/fts/stata.lua
@@ -1,0 +1,7 @@
+local stata = {}
+
+stata.stata = {
+	command = { "stata", "-q" },
+}
+
+return stata


### PR DESCRIPTION
The iron plugin already provides support for R, Julia and Python builtin REPLs. Add support for Stata command line interface (no batch mode).

This kernel has been tested with Stata 13 MP on Ubuntu 20.04, and it works as expected. This approach (`stata -q`) used to work up to Stata 15, so there's no reason the command-line mode would not work with Stata 17, especially since  [batch mode](https://www.stata.com/support/faqs/unix/batch-mode/) is still available for Unix users.

It is assumed that users have the executable `stata` available in their path. Usually, one of the many versions of Stata (SE, MP, IC) is symlinked into  `/usr/local/bin` or `/usr/local/stataXX/`, where `XX` stands for Stata version number, as `stata-se` or `stata-mp`. Sometimes, an additional symlink, `stata -> stata-[(mp|se)]`, is automatically created (by the install script or via Stata GUI). This PR assumes that such a link does exist, otherwise it has to be created by the user under his `$HOME` directory or in system-wide PATH. 
