### PR TITLE
iron.view: size can be a function

### DIFF
--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -200,6 +200,10 @@ iron.setup{
 
     -- Repl position. Check `iron.view` for more options
     repl_open_cmd = require("iron.view").curry.bottom(40),
+    -- Alternatively, pass a function, which is evalueated when a repl is open.
+    repl_open_cmd = require('iron.view').curry.right(function()
+        return vim.o.columns / 2
+    end),
 
     -- If the repl buffer is listed
     buflisted = false,

--- a/lua/iron/view.lua
+++ b/lua/iron/view.lua
@@ -15,9 +15,16 @@ view.openwin = function(cmd, buff)
   return winid
 end
 
+local function check_size(value, ...)
+  if type(value) == "function" then
+    return value(...)
+  end
+  return value
+end
 
 view.top = function(size, buff)
   local width = vim.o.columns
+  size = check_size(size, buff)
 
   return view.openfloat({
     relative = "editor",
@@ -31,6 +38,7 @@ end
 view.bottom = function(size, buff)
   local width = vim.o.columns
   local height = vim.o.lines
+  size = check_size(size, buff)
 
   return view.openfloat({
     relative = "editor",
@@ -44,6 +52,7 @@ end
 view.right = function(size, buff)
   local width = vim.o.columns
   local height = vim.o.lines
+  size = check_size(size, buff)
 
   return view.openfloat({
     relative = "editor",
@@ -56,6 +65,7 @@ end
 
 view.left = function(size, buff)
   local height = vim.o.lines
+  size = check_size(size, buff)
 
   return view.openfloat({
     relative = "editor",
@@ -69,6 +79,7 @@ end
 view.center = function(size, buff)
   local width = vim.o.columns
   local height = vim.o.lines
+  size = check_size(size, buff)
 
   return view.openfloat({
     relative = "editor",


### PR DESCRIPTION
If size is a function, size is evaluated when the float window is
opened. Useful if you want e.g. the REPL to be half of the screen.