### PR TITLE
feat: Add support for Mathematica/Wolfram

### DIFF
--- a/lua/iron/fts/init.lua
+++ b/lua/iron/fts/init.lua
@@ -15,6 +15,7 @@ local fts = {
   julia = require("iron.fts.julia"),
   lisp = require("iron.fts.lisp"),
   lua = require("iron.fts.lua"),
+  mma = require("iron.fts.mma"),
   ocaml = require("iron.fts.ocaml"),
   php = require("iron.fts.php"),
   prolog = require("iron.fts.prolog"),

--- a/lua/iron/fts/mma.lua
+++ b/lua/iron/fts/mma.lua
@@ -1,0 +1,7 @@
+local mma = {}
+
+mma.math = {
+  command = { "math" },
+}
+
+return mma


### PR DESCRIPTION
The Mathematica kernel (math) can used from the command-line, as well as
newest Wolfram utilities, including wolframscript. For interactive use,
the math standalone works quite well.

This assumes that Mathematica has been installed using default paths or that the `math` executable is available in `$PATH`. [Usually](http://ai.eecs.umich.edu/people/dreeves/mash/), on macOS or Linux this is one of  `/usr/bin/math`, `/usr/local/bin/math`, `/Applications/Mathematica.app/Contents/MacOS/MathKernel`, `/Applications/Mathematica Home Edition.app/Contents/MacOS/MathKernel`. Mac users will have to make an alias for `MathKernel` in their `/usr/local/bin`.
