### PR TITLE
add `desc` key for keymaps, change error to notification

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -573,7 +573,7 @@ core.setup = function(opts)
       else
         local mapping = vim.deepcopy(named_maps[key])
         table.insert(mapping, 2, lhs)
-        table.insert(mapping, {silent = true})
+        table.insert(mapping, {silent = true, desc = 'iron_repl_' .. key})
 
         vim.keymap.set(unpack(mapping))
       end

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -546,8 +546,8 @@ core.setup = function(opts)
   end
 
   if config.should_map_plug then
-    vim.api.nvim_err_writeln("iron.nvim: Mapping to <plug>.. is deprecated and will be removed in a later version")
-    vim.api.nvim_err_writeln("Please configure your mappings through iron.core.setup{keymaps = ...}")
+    vim.notify("iron.nvim: Mapping to <plug>.. is deprecated and will be removed in a later version", vim.log.levels.WARN)
+    vim.notify("Please configure your mappings through iron.core.setup{keymaps = ...}", vim.log.levels.WARN)
     for key, keymap in pairs(named_maps) do
       local mapping = vim.deepcopy(keymap)
       table.insert(mapping, 2, "<plug>(iron-" .. snake_to_kebab(key) .. ")")


### PR DESCRIPTION
as [https://github.com/nanotee/nvim-lua-guide#vimkeymap](https://github.com/nanotee/nvim-lua-guide#vimkeymap) at section `vim.keymap`  suggested,
we should add keymap descriptions for keymaps defined by `vim.keymap.set`, since lua function doesn't have good string representation, the keymap defined by lua function is not informative unless we give it a description