### PR TITLE
Keep cursor in source code window when toggling

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -161,9 +161,11 @@ end
 core.repl_for = function(ft)
   local meta = ll.get(ft)
   if ll.repl_exists(meta) then
+    local currwin = vim.api.nvim_get_current_win()
     config.visibility(meta.bufnr, function()
       local winid = ll.new_window(meta.bufnr)
       vim.api.nvim_win_set_buf(winid, meta.bufnr)
+      vim.api.nvim_set_current_win(currwin)
       return winid
     end)
     return meta


### PR DESCRIPTION
Hi @hkupty,

In my configuration I have set
```lua
visibility = require("iron.visibility").toggle
```

I observed that when calling `:IronRepl` the first time, a _REPL_ buffer is opened in a new window, while the cursor was kept in the source code window. Now every call of `:IronRepl` that gets that window back in the view made the cursor switch focus from the source code window to the _REPL_. 

Not sure if this is by design, but I'd rather like to have the cursor stay in the source code window, so I can send further commands to the _REPL_ without having to switch from the __REPL_ to the source code window again. 

This is what my little _PR_ is doing. So if you like that change, I'd love to have it on the master branch.

Just did some manual testing but
```lua
visibility = require("iron.visibility").single
visibility = require("iron.visibility").focus
```
seem to work as they did before.

Have a good one 🙂