### PR TITLE
remove deprecated nvim api nvim__set_hl_ns

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -552,7 +552,7 @@ core.setup = function(opts)
       bold = true
     }
 
-    vim.api.nvim__set_hl_ns(config.namespace)
+    vim.api.nvim_set_hl_ns(config.namespace)
     vim.api.nvim_set_hl(config.namespace, config.highlight_last, hl_cfg)
   end
 


### PR DESCRIPTION
Function's name was changed in recent nvim nightly versions.