### PR TITLE
feat: allow to build the repl command using a lua function

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ iron.setup {
     repl_definition = {
       sh = {
         -- Can be a table or a function that
-        -- returns a table
+        -- returns a table (see below)
         command = {"zsh"}
       }
     },
@@ -76,6 +76,24 @@ vim.keymap.set('n', '<space>rs', '<cmd>IronRepl<cr>')
 vim.keymap.set('n', '<space>rr', '<cmd>IronRestart<cr>')
 vim.keymap.set('n', '<space>rf', '<cmd>IronFocus<cr>')
 vim.keymap.set('n', '<space>rh', '<cmd>IronHide<cr>')
+```
+
+The repl `command` can also be a function:
+
+```lua
+iron.setup{
+  config = {
+    repl_definition = {
+      -- custom repl that loads the current file
+      haskell = {
+        command = function(meta)
+          local filename = vim.api.nvim_buf_get_name(meta.current_bufnr)
+          return { 'cabal', 'v2-repl', filename}
+        end
+      }
+    },
+  },
+}
 ```
 
 ### REPL windows

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ iron.setup {
     -- Your repl definitions come here
     repl_definition = {
       sh = {
+        -- Can be a table or a function that
+        -- returns a table
         command = {"zsh"}
       }
     },

--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -208,6 +208,7 @@ iron.setup{
 
      -- new, custom repl
       lua = {
+        -- Can be a table or a function that returns a table
         command = {"my-lua-repl", "-arg"}
       }
     },

--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -208,7 +208,7 @@ iron.setup{
 
      -- new, custom repl
       lua = {
-        -- Can be a table or a function that returns a table
+        -- Can be a table or a function that returns a table (see below)
         command = {"my-lua-repl", "-arg"}
       }
     },
@@ -253,6 +253,24 @@ iron.setup{
   highlight = {
     italic = true
   }
+}
+```
+
+The repl command can also be a function:
+
+```
+iron.setup{
+  config = {
+    repl_definition = {
+      -- custom repl that loads the current file
+      haskell = {
+        command = function(meta)
+          local filename = vim.api.nvim_buf_get_name(meta.current_bufnr)
+          return { 'cabal', 'v2-repl', filename}
+        end
+      }
+    },
+  },
 }
 ```
 

--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -53,10 +53,11 @@ end
 -- @param repl definition of the repl being created
 -- @param repl.command table with the command to be invoked.
 -- @param bufnr Buffer to be used
+-- @param current_bufnr Current buffer
 -- @param opts Options passed through to the terminal
 -- @warning changes current window's buffer to bufnr
 -- @return unsaved metadata about created repl
-ll.create_repl_on_current_window = function(ft, repl, bufnr, opts)
+ll.create_repl_on_current_window = function(ft, repl, bufnr, current_bufnr, opts)
   vim.api.nvim_win_set_buf(0, bufnr)
   -- TODO Move this out of this function
   -- Checking config should be done on an upper layer.
@@ -73,9 +74,13 @@ ll.create_repl_on_current_window = function(ft, repl, bufnr, opts)
     end
   end
 
-  local cmd = type(repl.command) == 'function' 
-    and repl.command()
-    or repl.command
+  local cmd = repl.command
+  if type(repl.command) == 'function' then
+    local meta = {
+      current_bufnr = current_bufnr,
+    }
+    cmd = repl.command(meta)
+  end
   local job_id = vim.fn.termopen(cmd, opts)
 
   return {

--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -53,7 +53,7 @@ end
 -- @param repl definition of the repl being created
 -- @param repl.command table with the command to be invoked.
 -- @param bufnr Buffer to be used
--- @param opts Options passed throught to the terminal
+-- @param opts Options passed through to the terminal
 -- @warning changes current window's buffer to bufnr
 -- @return unsaved metadata about created repl
 ll.create_repl_on_current_window = function(ft, repl, bufnr, opts)
@@ -73,7 +73,10 @@ ll.create_repl_on_current_window = function(ft, repl, bufnr, opts)
     end
   end
 
-  local job_id = vim.fn.termopen(repl.command, opts)
+  local cmd = type(repl.command) == 'function' 
+    and repl.command()
+    or repl.command
+  local job_id = vim.fn.termopen(cmd, opts)
 
   return {
     ft = ft,


### PR DESCRIPTION
This is useful e.g. if the command has to take a path or directory as an argument.

In my case, `cabal new-repl` has to take the package name as an argument if a project has more than one package.
With a function, I can determine the package's name and build the appropriate command.

Another use case would be if there are different ways to open a repl.
In Haskell, the command may have to be

* `stack ghci ...`
* `cabal new-repl...`
* `ghci ...`

depending on the build tool.