### PR TITLE
Add DAP repl integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ iron.setup {
       -- or return a string name such as the following
       -- return "iron"
     end,
+    -- Send selections to the DAP repl if an nvim-dap session is running.
+    dap_integration = true
     -- How the repl window will be displayed
     -- See below for more information
     repl_open_cmd = view.bottom(40),

--- a/lua/iron/dap.lua
+++ b/lua/iron/dap.lua
@@ -1,0 +1,31 @@
+local M = {}
+
+local is_dap_integration_enabled = false
+
+--- Sets up a hook to keep track of the DAP session state.
+function M.enable_integration()
+  is_dap_integration_enabled = true
+end
+
+--- Returns true if dap_integration is enabled and a dap session is running.
+--- This function will always return false if dap_integration is not enabled.
+--- @return boolean
+function M.is_dap_session_running()
+  local has_dap, dap = pcall(require, 'dap')
+  return has_dap and is_dap_integration_enabled and dap.session() ~= nil
+end
+
+--- Send the lines to the dap-repl
+--- @param lines string|string[]
+function M.send_to_dap(lines)
+  local text
+  if type(lines) == 'table' then
+    text = table.concat(lines, "\n"):gsub('\r', '')
+  else
+    text = lines
+  end
+  require('dap').repl.execute(text)
+  require('dap').repl.open()
+end
+
+return M


### PR DESCRIPTION
Adds an integration with [nvim-dap](https://github.com/mfussenegger/nvim-dap) to send selections to the dap-repl while an nvim-dap session is running.

I've been using this patch for a few weeks and this is an extremely ergonomic way to debug and inspect variables.

This integration is off by default and completely optional - if dap isn't installed, the integration is bypassed.