### PR TITLE
feat(core): use send_raw to fix clear action

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -282,6 +282,27 @@ core.send = function(ft, data)
   end
 end
 
+--- Sends unprocessed data to the REPL (no newline, no formatting).
+-- Useful for sending raw control characters like <C-l>.
+--
+-- @tparam[opt] string ft Filetype for REPL resolution (if none attached)
+-- @tparam string data Raw string to send
+core.send_raw = function(ft, data)
+  local meta = vim.b[0].repl
+
+  if not meta or not ll.repl_exists(meta) then
+    ft = ft or ll.get_buffer_ft(0)
+    if data == nil then return end
+    meta = ll.get(ft)
+  end
+
+  if not ll.repl_exists(meta) then
+    meta = core.repl_for(ft)
+  end
+
+  ll.send_raw(meta, data)
+end
+
 core.send_file = function(ft)
   core.send(ft, vim.api.nvim_buf_get_lines(0, 0, -1, false))
 end
@@ -717,7 +738,7 @@ local named_maps = {
   cr = { { 'n' }, function() core.send(nil, string.char(13)) end },
   interrupt = { { 'n' }, function() core.send(nil, string.char(03)) end },
   exit = { { 'n' }, core.close_repl },
-  clear = { { 'n' }, function() core.send(nil, string.char(12)) end },
+  clear = { { 'n' }, function() core.send_raw(nil, string.char(12)) end },
 }
 
 local tmp_migration = {

--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -181,6 +181,12 @@ ll.send_to_repl = function(meta, data)
   end
 end
 
+--- Sends raw data to an existing repl without any formatting.
+-- @tparam table meta metadata for repl. Should not be nil
+-- @tparam string data A string to be sent to the repl
+ll.send_raw = function(meta, data)
+  vim.fn.chansend(meta.job, data)
+end
 
 --- Reshapes the repl window according to a preset config described in views
 -- @tparam table meta metadata for the repl


### PR DESCRIPTION
### Summary

Fixes an issue with the default `clear` action sending formatted data instead of raw Ctrl+L (`^L`) to the REPL. Introduced `send_raw` function to cleanly support raw input.

### Changes

- Added `lowlevel.send_raw(meta, data)`
- Added high-level `send_raw(ft, data)` wrapper
- Updated `named_maps.clear` to use the new method

### Motivation

The current `core.send` wraps all output (e.g., appends `\n`), which breaks REPLs that interpret `^L` literally (e.g., Python, IPython). This change makes `clear` more correct and minimal.

Thanks for the great plugin :)