### PR TITLE
Fix extra blank line after each code line on Windows

### DIFF
--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -186,7 +186,7 @@ ll.send_to_repl = function(meta, data)
   --TODO check vim.api.nvim_chan_send
   --TODO tool to get the progress of the chan send function
   if is_windows then
-    vim.fn.chansend(meta.job, table.concat(dt, "\n"))
+    vim.fn.chansend(meta.job, table.concat(dt, "\r"))
   else
     vim.fn.chansend(meta.job, dt)
   end


### PR DESCRIPTION
This pull request addresses an [issue](https://github.com/Vigemus/iron.nvim/issues/426) with extra blank lines on Windows, which causes additional blank lines between code lines in IPython and the REPL of Python 3.13/3.14. Example:
```
Python 3.11.7 | packaged by Anaconda, Inc. | (main, Dec 15 2023, 18:05:47) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.20.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: class MyClass:
   ...:
   ...:         def hello(self):
   ...:
   ...:                     print('hello python\n')
   ...:

In [2]:

In [2]:

In [2]:

In [2]: c = MyClass()

In [3]:

In [3]: c.hello()
```
The issue stems from `vim.fn.chansend` appending `\r\n` to each piece of data on Windows. In Python 3.13/3.14 and IPython, `\r\n` is interpreted as two line breaks instead of one, resulting in an extra blank line after each line of code.
To fix this, we manually join each piece of data with `\r`.