### PR TITLE
Fix the issue of five extra blank lines on Windows

### DIFF
--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -144,7 +144,9 @@ common.bracketed_paste_python = function(lines, extras)
     -- requires and extra newline in order to execute the code
     table.insert(result, newline)
   else
-    table.insert(result, "")
+    if not is_windows then
+      table.insert(result, "")
+    end
   end
 
   if ptpython then

--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -5,6 +5,7 @@ local fts = require("iron.fts")
 local providers = require("iron.providers")
 local format = require("iron.fts.common").format
 local view = require("iron.view")
+local is_windows = require("iron.util.os").is_windows
 
 --- Low level functions for iron
 -- This is needed to reduce the complexity of the user API functions.
@@ -184,7 +185,11 @@ ll.send_to_repl = function(meta, data)
 
   --TODO check vim.api.nvim_chan_send
   --TODO tool to get the progress of the chan send function
-  vim.fn.chansend(meta.job, dt)
+  if is_windows then
+    vim.fn.chansend(meta.job, table.concat(dt, "\r"))
+  else
+    vim.fn.chansend(meta.job, dt)
+  end
 
   if window ~= -1 then
     vim.api.nvim_win_set_cursor(window, {vim.api.nvim_buf_line_count(meta.bufnr), 0})


### PR DESCRIPTION
This PR resolves an issue on Windows where `send_file` and `send_mark` tasks in ipython and Python 3.13/3.14 REPL result in an additional five blank lines at the end. Example:
```
>>> print('hello world')
hello world
>>> 
>>> 
>>> 
>>> 
>>> 
```

The issue arises because `core.send` adds an extra `\r` for string-type data and two `\r` for other data types on Windows. In `common.bracket_paste_python`, these are treated as two separate arrays, each appended with an empty data item. During a single `send_file` or `send_mark`, the following three groups of data are sent:
```
{ "print('hello world')", "" }
{ "\r", "" }
{ "\r", "" }
```
On Windows, each empty data item causes an extra line break. This results in five blank lines instead of the expected two. This PR fixes the issue.