### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ iron.setup {
         command = { "python3" },  -- or { "ipython", "--no-autoindent" }
         format = common.bracketed_paste_python,
         block_dividers = { "# %%", "#%%" },
-        env = {PYTHON_BASIC_REPL = "1"} --this is needed for python3.13 and up.
       }
     },
     -- set the file type of the newly created repl to ft


### PR DESCRIPTION
With the help of PRs [#435](https://github.com/Vigemus/iron.nvim/pull/435) and [#436](https://github.com/Vigemus/iron.nvim/pull/436), we no longer need to set the `PYTHON_BASIC_REPL` environment variable to enable the legacy REPL for Python—the new REPL will be much more user-friendly.